### PR TITLE
Create new result dict instead of trying to use str as dict

### DIFF
--- a/custom_components/greenchoice/sensor.py
+++ b/custom_components/greenchoice/sensor.py
@@ -173,6 +173,7 @@ class GreenchoiceApiData:
 
     @Throttle(MIN_TIME_BETWEEN_UPDATES)
     def update(self):
+        self.result = {}
 
         try:
             response = http.client.HTTPSConnection(self._resource, timeout=10)


### PR DESCRIPTION
Any error in `update` overwrites `self.result` to a string, which breaks any future invocations to `update` because it expects `self.result` to be a dictionary.